### PR TITLE
Added multiStatements option to migrations DSN.

### DIFF
--- a/mwcmd/main.go
+++ b/mwcmd/main.go
@@ -215,7 +215,7 @@ func openDB(cfg config) (*mw.DB, error) {
 
 	conPath := fmt.Sprintf("tcp(%s:%d)", cfg.Host, cfg.Port)
 	dsn := fmt.Sprintf(
-		"%s:%s@%s/%s?tls=%s&parseTime=true&charset=utf8mb4&collation=utf8mb4_unicode_ci&sql_mode=''",
+		"%s:%s@%s/%s?tls=%s&parseTime=true&charset=utf8mb4&collation=utf8mb4_unicode_ci&sql_mode=''&multiStatements=true",
 		cfg.User,
 		cfg.Password,
 		conPath,


### PR DESCRIPTION
This pull request enables `multiStatements` so it's possible to run migrations like:
````
insert into user2020 values ('u1', 'pwd', 1, 'stripe', 'ok', now(), now());
insert into user_email2020 values ('u1sha1', 'u1', 'user1@email.com', 1, now(), now(), default);
````